### PR TITLE
Update on declaration of NgModule

### DIFF
--- a/dist/ng2-sticky.module.d.ts
+++ b/dist/ng2-sticky.module.d.ts
@@ -1,4 +1,11 @@
 import { Ng2StickyDirective } from "./ng2-sticky.directive";
-export { Ng2StickyDirective };
-export declare class Ng2StickyModule {
+import { NgModule } from '@angular/core';
+
+@NgModule({
+  declarations: [
+    Ng2StickyDirective
+  ],
+  exports: [Ng2StickyDirective]
+})
+export class Ng2StickyModule {
 }


### PR DESCRIPTION
Fix for this issue: https://github.com/ng2-ui/ng2-sticky/issues/5

Using ng2-sticky on this angular 2 app:

```
  "dependencies": {
    "@angular/common": "~2.4.4",
    "@angular/compiler": "~2.4.4",
    "@angular/core": "~2.4.4",
    "@angular/forms": "~2.4.4",
    "@angular/http": "~2.4.4",
    "@angular/platform-browser": "~2.4.4",
    "@angular/platform-browser-dynamic": "~2.4.4",
    "@angular/router": "~3.4.4",
    "bootstrap": "^3.3.7",
    "core-js": "^2.4.1" ,
    "ng2-sticky": "^0.4.1",
    "rxjs": "^5.0.3",
    "ts-helpers": "^1.1.1",
    "zone.js": "^0.7.6"
  },
  "devDependencies": {
    "@angular/compiler-cli": "^2.3.1",
    "@types/jasmine": "2.5.38",
    "@types/node": "^7.0.3",
    "angular-cli": "1.0.0-beta.24",
    "codelyzer": "~2.0.0-beta.4",
    "jasmine-core": "2.5.2",
    "jasmine-spec-reporter": "2.5.0",
    "karma": "1.2.0",
    "karma-chrome-launcher": "^2.0.0",
    "karma-cli": "^1.0.1",
    "karma-jasmine": "^1.0.2",
    "karma-remap-istanbul": "^0.2.1",
    "protractor": "5.0.0",
    "ts-node": "2.0.0",
    "tslint": "4.3.1",
    "typescript": "latest"
  },
  "gulp": "3.9.1",
  "gulp-sourcemaps": "2.0.0-alpha",
  "del": "2.2.0"
}

```

Produces this error:

![image](https://cloud.githubusercontent.com/assets/237025/22411777/7a0e24d8-e6e2-11e6-8f1c-1d07cf65ebdf.png)
